### PR TITLE
TG-2063 Allow broadcast packets in tun mode

### DIFF
--- a/src/tap-windows6.vcxproj.in
+++ b/src/tap-windows6.vcxproj.in
@@ -172,7 +172,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DisableSpecificWarnings>%(DisableSpecificWarnings);4201;4214;4100;4101;4200;4057;4127</DisableSpecificWarnings>
       <TreatWarningAsError>false</TreatWarningAsError>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);TAP_DRIVER_MAJOR_VERSION=@PRODUCT_TAP_WIN_MAJOR@;TAP_DRIVER_MINOR_VERSION=@PRODUCT_TAP_WIN_MINOR@;NDIS_WDM=1;NDIS_MINIPORT_DRIVER=1;NDIS620_MINIPORT=1;NDIS630_MINIPORT=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);TAP_DRIVER_MAJOR_VERSION=@PRODUCT_TAP_WIN_MAJOR@;TAP_DRIVER_MINOR_VERSION=@PRODUCT_TAP_WIN_MINOR@;NDIS_WDM=1;NDIS_MINIPORT_DRIVER=1;NDIS620_MINIPORT=1;NDIS630_MINIPORT=1;ENABLE_TUN_BROADCAST=1</PreprocessorDefinitions>
       <EnablePREfast Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</EnablePREfast>
     </ClCompile>
     <Link>

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -694,13 +694,13 @@ Return Value:
             {
                 goto no_queue;
             }
-
+#if defined(DISABLE_TUN_BROADCAST)
             // Only accept directed packets, not broadcasts.
             if (memcmp (e, &Adapter->m_TapToUser, ETHERNET_HEADER_SIZE))
             {
                 goto no_queue;
             }
-
+#endif
             // Packet looks like IPv4, queue it. :-)
             tapPacket->m_SizeFlags |= TP_TUN;
             break;

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -694,7 +694,8 @@ Return Value:
             {
                 goto no_queue;
             }
-#if defined(DISABLE_TUN_BROADCAST)
+
+#ifndef ENABLE_TUN_BROADCAST
             // Only accept directed packets, not broadcasts.
             if (memcmp (e, &Adapter->m_TapToUser, ETHERNET_HEADER_SIZE))
             {


### PR DESCRIPTION
Enabling broadcasts can affect the load on VIPER because in that case more packets will be captured and have to be filtered on the hydra/viper side.


Jira ticket: https://twingate.atlassian.net/browse/TG-2063